### PR TITLE
Ignore items that generate exceptions when trying to download them

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -51,20 +51,26 @@ def downloadFiles(askedVideos, askedFiles, link, arielauth):
             1), "name":item.getText().replace('/','-').replace('\\','-')}for sublist in attacched_materials_non_flat for item in sublist]
 
         for materiale in materials:
-            print(f"Sto scaricando {materiale}")
-            m = re.search('.+/(.+)', materiale).group(1).strip('/')
-            r = requests.get(materiale, allow_redirects=True)
-            os.makedirs(os.path.dirname("Result/"), exist_ok=True)
-            with open('Result/' + m, 'wb+') as f:
-                f.write(r.content)
+            try:
+                print(f"Sto scaricando {materiale}")
+                m = re.search('.+/(.+)', materiale).group(1).strip('/')
+                r = requests.get(materiale, allow_redirects=True)
+                os.makedirs(os.path.dirname("Result/"), exist_ok=True)
+                with open('Result/' + m, 'wb+') as f:
+                    f.write(r.content)
+            except:
+                pass
 
         for materiale in attached_materials:
-            print(f"Sto scaricando {materiale['name']}")
-            r = requests.post(materiale["url"],
-                              allow_redirects=True, cookies=cookies)
-            os.makedirs(os.path.dirname("Result/"), exist_ok=True)
-            with open('Result/' + materiale["name"], 'wb+') as f:
-                f.write(r.content)
+            try:
+                print(f"Sto scaricando {materiale['name']}")
+                r = requests.post(materiale["url"],
+                                  allow_redirects=True, cookies=cookies)
+                os.makedirs(os.path.dirname("Result/"), exist_ok=True)
+                with open('Result/' + materiale["name"], 'wb+') as f:
+                    f.write(r.content)
+            except:
+                pass
         print("Ho finito di scaricare slide e altri materiali.")
 
     if askedVideos:

--- a/downloader.py
+++ b/downloader.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 # coding: utf-8
-from bs4 import BeautifulSoup as bs
 import argparse
 import re
-import requests
 import os
+from sys import stderr
+from traceback import print_exc
+
+import requests
+from bs4 import BeautifulSoup as bs
 
 
 def login(username, password):
@@ -58,8 +61,8 @@ def downloadFiles(askedVideos, askedFiles, link, arielauth):
                 os.makedirs(os.path.dirname("Result/"), exist_ok=True)
                 with open('Result/' + m, 'wb+') as f:
                     f.write(r.content)
-            except:
-                pass
+            except Exception:
+                print_exc()
 
         for materiale in attached_materials:
             try:
@@ -69,8 +72,8 @@ def downloadFiles(askedVideos, askedFiles, link, arielauth):
                 os.makedirs(os.path.dirname("Result/"), exist_ok=True)
                 with open('Result/' + materiale["name"], 'wb+') as f:
                     f.write(r.content)
-            except:
-                pass
+            except Exception:
+                print_exc()
         print("Ho finito di scaricare slide e altri materiali.")
 
     if askedVideos:

--- a/downloader.py
+++ b/downloader.py
@@ -32,7 +32,7 @@ def arielUrl(arg: str):
     raise argparse.ArgumentTypeError(f"'{arg}' non è un link Ariel valido!")
 
 
-def downloadFiles(askedVideos, askedFiles, link, arielauth):
+def downloadFiles(askedVideos, askedFiles, link, arielauth, quiet):
     cookies = {"arielauth": f"{arielauth}"}
 
     r = requests.post(link, allow_redirects=True, cookies=cookies)
@@ -62,7 +62,8 @@ def downloadFiles(askedVideos, askedFiles, link, arielauth):
                 with open('Result/' + m, 'wb+') as f:
                     f.write(r.content)
             except Exception:
-                print_exc()
+                if not quiet:
+                    print_exc()
 
         for materiale in attached_materials:
             try:
@@ -73,7 +74,8 @@ def downloadFiles(askedVideos, askedFiles, link, arielauth):
                 with open('Result/' + materiale["name"], 'wb+') as f:
                     f.write(r.content)
             except Exception:
-                print_exc()
+                if not quiet:
+                    print_exc()
         print("Ho finito di scaricare slide e altri materiali.")
 
     if askedVideos:
@@ -110,6 +112,8 @@ def readInputs():
                         help='Nome utente con cui fare il login')
     parser.add_argument('-p', '--password', type=str,
                         help='Password con cui fare il login')
+    parser.add_argument('-q', '--quiet', action="store_true", default=False,
+                        help='Nasconde i messaggi di errore')
 
     args = parser.parse_args()
 
@@ -120,9 +124,9 @@ def readInputs():
 
     # default
     if not args.video and not args.slide:
-        downloadFiles(True, True, args.url, args.arielAuth)
+        downloadFiles(True, True, args.url, args.arielAuth, args.quiet)
     else:
-        downloadFiles(args.video, args.slide, args.url, args.arielAuth)
+        downloadFiles(args.video, args.slide, args.url, args.arielAuth, args.quiet)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This was done because the program currently halts if any exception is raised the parsing of the page or download of the item. Since it's very common to find items that generate an exception during parsing (e.g. a professor's email), I thought it would be better to simply ignore said item.